### PR TITLE
Allow the usage of hyphens in targetPath and sourcePath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+## 3.1.0
+
+#### `upload()`
+
+- Allow the usage of hyphens in `sourcePath` and `targetPath`.
+
 ## 3.0.0
 
 > `viewport-uploader` is the new `gulp-viewport`.

--- a/index.js
+++ b/index.js
@@ -29,8 +29,8 @@ const targetEnvTemplate = {
 };
 
 const uploadTemplate = {
-    'targetPath': /^(\w+\/)*$/i,
-    'sourcePath': /^(\w+\/)*$/i,
+    'targetPath': /^(([a-zA-Z0-9\_\-]*)+\/*)*$/i,
+    'sourcePath': /^(([a-zA-Z0-9\_\-]*)+\/*)*$/i,
     'glob': /.*/i,
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k15t/viewport-uploader",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A node module to upload theme resources to Scroll Viewport.",
   "dependencies": {
     "chalk": "^3.0.0",


### PR DESCRIPTION
Currently the uploader won't work with a path like this: 'uploads/this-directory/'

Therefore I adjusted the regular expression to also match words containing hyphens.