### PR TITLE
Add protection against XSRF attacks.

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -66,7 +66,11 @@ function uploadTheme(formData) {
     return fetch(this.restUrlForThemeResources,
         {
             method: 'POST',
-            headers: { 'Authorization': this.autorisation, ...formData.getHeaders() },
+            headers: {
+                'Authorization': this.autorisation,
+                'X-Atlassian-Token': 'no-check',
+                ...formData.getHeaders()
+            },
             body: formData
         })
         .then(checkPermissionError.bind(this))


### PR DESCRIPTION
Add `'X-Atlassian-Token': 'no-check'` header to `uploadTheme` POST request.

This should be merged before the changes in the Java App. The presented changes shouldn't lead to errors since the App will ignore the added header, since it has a `XsrfProtectionExcluded` annotation set on the regarding REST endpoint.